### PR TITLE
Fixed potential out of bounds access.

### DIFF
--- a/GTE/Mathematics/TriangulateEC.h
+++ b/GTE/Mathematics/TriangulateEC.h
@@ -1223,8 +1223,14 @@ namespace gte
             {
                 int currSPrev = V(i).sPrev;
                 int currSNext = V(i).sNext;
-                V(currSPrev).sNext = currSNext;
-                V(currSNext).sPrev = currSPrev;
+                if (currSPrev != -1)
+                {
+                    V(currSPrev).sNext = currSNext;
+                }
+                if (currSNext != -1)
+                {
+                    V(currSNext).sPrev = currSPrev;
+                }
                 V(i).sNext = -1;
                 V(i).sPrev = -1;
             }


### PR DESCRIPTION
In some cases, the currSNext and currSPrev indices can be -1 when removing a reflex vertex. Without checking for this case, attempting to re-assign the connections can cause out of bounds access, resulting in memory corruption.

This was observed when processing a large dataset, where it corrupted memory used by another structure and caused the tool to fail. When running through valgrind to check for memory errors, this came up as the cause, and this change fixed the memory corruption.