### PR TITLE
Switched manifold meshes to use unique_ptr.

### DIFF
--- a/GTE/Mathematics/ConformalMapGenus0.h
+++ b/GTE/Mathematics/ConformalMapGenus0.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.0.2019.08.13
+// Version: 4.0.2021.04.22
 
 #pragma once
 
@@ -77,7 +77,7 @@ namespace gte
                 value = (Real)0;
                 for (int j = 0; j < 2; ++j)
                 {
-                    auto triangle = element.second->T[j].lock();
+                    auto triangle = element.second->T[j];
                     for (i = 0; i < 3; ++i)
                     {
                         v2 = triangle->V[i];

--- a/GTE/Mathematics/ConstrainedDelaunay2.h
+++ b/GTE/Mathematics/ConstrainedDelaunay2.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.0.2021.03.15
+// Version: 4.0.2021.04.22
 
 #pragma once
 
@@ -231,7 +231,7 @@ namespace gte
             auto const& vmap = this->mGraph.GetVertices();
             auto viter = vmap.find(v);
             LogAssert(viter != vmap.end(), "Failed to find vertex in graph.");
-            auto vertex = viter->second;
+            auto vertex = viter->second.get();
             LogAssert(vertex != nullptr, "Unexpected condition.");
 
             for (auto const& linkTri : vertex->TAdjacent)
@@ -269,7 +269,7 @@ namespace gte
             auto const& tmap = this->mGraph.GetTriangles();
             auto titer = tmap.find(TriangleKey<true>(localEdge[0], v0, v1));
             LogAssert(titer != tmap.end(), CDTMessage());
-            auto tri = titer->second;
+            auto tri = titer->second.get();
             LogAssert(tri, CDTMessage());
 
             // Keep track of the right and left polylines that bound the
@@ -732,7 +732,7 @@ namespace gte
             auto const& vmap = this->mGraph.GetVertices();
             auto viter = vmap.find(v);
             LogAssert(viter != vmap.end(), "Failed to find vertex in graph.");
-            auto vertex = viter->second;
+            auto vertex = viter->second.get();
             LogAssert(vertex != nullptr, "Unexpected condition.");
 
             for (auto const& linkTri : vertex->TAdjacent)
@@ -838,7 +838,7 @@ namespace gte
             auto const& tmap = this->mGraph.GetTriangles();
             auto titer = tmap.find(TriangleKey<true>(localEdge[0], v0, v1));
             LogAssert(titer != tmap.end(), CDTMessage());
-            auto tri = titer->second;
+            auto tri = titer->second.get();
             LogAssert(tri, CDTMessage());
 
             // Keep track of the right and left polylines that bound the

--- a/GTE/Mathematics/ConvexHull3.h
+++ b/GTE/Mathematics/ConvexHull3.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.0.2021.02.02
+// Version: 4.0.2021.04.22
 
 #pragma once
 
@@ -424,7 +424,7 @@ namespace gte
         void Hull3(std::vector<size_t>& hull, size_t numSorted, size_t* sorted,
             VETManifoldMesh& hullMesh, size_t& current)
         {
-            using TrianglePtr = std::shared_ptr<VETManifoldMesh::Triangle>;
+            using TrianglePtr = VETManifoldMesh::Triangle*;
             // The hull points previous to the current one are coplanar and
             // are the vertices of a convex polygon. To initialize the 3D
             // hull, use triangles from a triangle fan of the convex polygon
@@ -525,7 +525,7 @@ namespace gte
                     visible.pop();
                     for (size_t i = 0; i < 3; ++i)
                     {
-                        auto adj = tri->T[i].lock();
+                        auto adj = tri->T[i];
                         if (adj)
                         {
                             if (ToPlane(adj->V[0], adj->V[1], adj->V[2], h1) <= 0)

--- a/GTE/Mathematics/GenerateMeshUV.h
+++ b/GTE/Mathematics/GenerateMeshUV.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.0.2019.08.13
+// Version: 4.0.2021.04.22
 
 #pragma once
 
@@ -157,7 +157,7 @@ namespace gte
         std::vector<int> mVertexInfo;
         int mNumBoundaryEdges, mBoundaryStart;
         typedef ETManifoldMesh::Edge Edge;
-        std::set<std::shared_ptr<Edge>> mInteriorEdges;
+        std::set<Edge*> mInteriorEdges;
 
         // The vertex graph required to set up a sparse linear system of
         // equations to determine the texture coordinates.
@@ -218,10 +218,10 @@ namespace gte
                 ++numAdjacencies[element.first.V[0]];
                 ++numAdjacencies[element.first.V[1]];
 
-                if (element.second->T[1].lock())
+                if (element.second->T[1])
                 {
                     // This is an interior edge.
-                    mInteriorEdges.insert(element.second);
+                    mInteriorEdges.insert(element.second.get());
                 }
                 else
                 {
@@ -229,7 +229,7 @@ namespace gte
                     // vertex indices to make the edge counterclockwise.
                     ++mNumBoundaryEdges;
                     int v0 = element.second->V[0], v1 = element.second->V[1];
-                    auto tri = element.second->T[0].lock();
+                    auto tri = element.second->T[0];
                     int i;
                     for (i = 0; i < 3; ++i)
                     {
@@ -468,7 +468,7 @@ namespace gte
                         {
                             // Find the vertex of triangle T[j] opposite edge
                             // <X0,X1>.
-                            auto tri = edge->T[j].lock();
+                            auto tri = edge->T[j];
                             int k;
                             for (k = 0; k < 3; ++k)
                             {

--- a/GTE/Mathematics/MinimumVolumeBox3.h
+++ b/GTE/Mathematics/MinimumVolumeBox3.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.9.2021.01.17
+// Version: 4.9.2021.04.22
 
 #pragma once
 #include <Mathematics/Logger.h>
@@ -442,10 +442,10 @@ namespace gte
             // is a std::unordered_map. The vertices must be sorted here to
             // satisfy condition2.
             auto const& vmap = mesh.GetVertices();
-            std::map<int, std::shared_ptr<VETManifoldMesh::Vertex>> sortedVMap;
+            std::map<int, VETManifoldMesh::Vertex*> sortedVMap;
             for (auto const& element : vmap)
             {
-                sortedVMap.insert(element);
+                sortedVMap.emplace(element.first, element.second.get());
             }
 
             size_t numAdjacentPool = 0;
@@ -472,11 +472,11 @@ namespace gte
             mEdges.resize(emap.size());
             mTriangles.resize(tmap.size());
 
-            std::map<std::shared_ptr<ETManifoldMesh::Edge>, size_t> edgeIndexMap;
+            std::map<ETManifoldMesh::Edge*, size_t> edgeIndexMap;
             size_t index = 0;
             for (auto const& element : emap)
             {
-                edgeIndexMap.insert(std::make_pair(element.second, index));
+                edgeIndexMap.emplace(element.second.get(), index);
                 for (size_t j = 0; j < 2; ++j)
                 {
                     mEdges[index].V[j] = (size_t)element.second->V[j];
@@ -484,11 +484,11 @@ namespace gte
                 ++index;
             }
 
-            std::map<std::shared_ptr<ETManifoldMesh::Triangle>, size_t> triangleIndexMap;
+            std::map<ETManifoldMesh::Triangle*, size_t> triangleIndexMap;
             index = 0;
             for (auto const& element : tmap)
             {
-                triangleIndexMap.insert(std::make_pair(element.second, index));
+                triangleIndexMap.emplace(element.second.get(), index);
                 for (size_t j = 0; j < 3; ++j)
                 {
                     mTriangles[index].V[j] = (size_t)element.second->V[j];
@@ -501,7 +501,7 @@ namespace gte
             {
                 for (size_t j = 0; j < 2; ++j)
                 {
-                    auto tri = element.second->T[j].lock();
+                    auto tri = element.second->T[j];
                     auto titer = triangleIndexMap.find(tri);
                     mEdges[index].T[j] = titer->second;
                 }
@@ -513,13 +513,13 @@ namespace gte
             {
                 for (size_t j = 0; j < 3; ++j)
                 {
-                    auto edg = element.second->E[j].lock();
+                    auto edg = element.second->E[j];
                     auto eiter = edgeIndexMap.find(edg);
                     mTriangles[index].E[j] = eiter->second;
                 }
                 for (size_t j = 0; j < 3; ++j)
                 {
-                    auto tri = element.second->T[j].lock();
+                    auto tri = element.second->T[j];
                     auto titer = triangleIndexMap.find(tri);
                     mTriangles[index].T[j] = titer->second;
                 }

--- a/GTE/Mathematics/PlanarMesh.h
+++ b/GTE/Mathematics/PlanarMesh.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.0.2019.08.13
+// Version: 4.0.2021.04.22
 
 #pragma once
 
@@ -144,7 +144,7 @@ namespace gte
                 auto element = tmap.find(key);
                 for (int i = 0; i < 3; ++i)
                 {
-                    auto adj = element->second->T[i].lock();
+                    auto adj = element->second->T[i];
                     if (adj)
                     {
                         key = TriangleKey<true>(adj->V[0], adj->V[1], adj->V[2]);
@@ -194,7 +194,7 @@ namespace gte
             {
                 for (int i = 0; i < 3; ++i, ++vIndex)
                 {
-                    auto adj = element.second->T[i].lock();
+                    auto adj = element.second->T[i];
                     if (adj)
                     {
                         TriangleKey<true> key(adj->V[0], adj->V[1], adj->V[2]);

--- a/GTE/Mathematics/TriangulateCDT.h
+++ b/GTE/Mathematics/TriangulateCDT.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.0.2020.11.30
+// Version: 4.0.2021.04.22
 
 #pragma once
 
@@ -439,7 +439,7 @@ namespace gte
                 LogAssert(eiter != emap.end(), "Unexpected condition.");
                 auto const& edge = eiter->second;
                 LogAssert(edge, "Unexpected condition.");
-                auto tri0 = edge->T[0].lock();
+                auto tri0 = edge->T[0];
                 LogAssert(tri0, "Unexpected condition.");
                 if (tri0->WhichSideOfEdge(v0, v1) == node.chirality)
                 {
@@ -447,7 +447,7 @@ namespace gte
                 }
                 else
                 {
-                    auto tri1 = edge->T[1].lock();
+                    auto tri1 = edge->T[1];
                     if (tri1)
                     {
                         region.insert(TriangleKey<true>(tri1->V[0], tri1->V[1], tri1->V[2]));
@@ -487,7 +487,7 @@ namespace gte
                 LogAssert(tri, "Unexpected condition.");
                 for (size_t j = 0; j < 3; ++j)
                 {
-                    auto edge = tri->E[j].lock();
+                    auto edge = tri->E[j];
                     if (edge)
                     {
                         auto siter = edges.find(EdgeKey<false>(edge->V[0], edge->V[1]));
@@ -495,7 +495,7 @@ namespace gte
                         {
                             // The edge is not constrained, so it allows the
                             // search to continue.
-                            auto adj = tri->T[j].lock();
+                            auto adj = tri->T[j];
                             if (adj)
                             {
                                 TriangleKey<true> akey(adj->V[0], adj->V[1], adj->V[2]);
@@ -948,7 +948,7 @@ namespace gte
                 LogAssert(eiter != emap.end(), "Unexpected condition.");
                 auto const& edge = eiter->second;
                 LogAssert(edge, "Unexpected condition.");
-                auto tri0 = edge->T[0].lock();
+                auto tri0 = edge->T[0];
                 LogAssert(tri0, "Unexpected condition.");
                 if (tri0->WhichSideOfEdge(v0, v1) == node.chirality)
                 {
@@ -956,7 +956,7 @@ namespace gte
                 }
                 else
                 {
-                    auto tri1 = edge->T[1].lock();
+                    auto tri1 = edge->T[1];
                     if (tri1)
                     {
                         region.insert(TriangleKey<true>(tri1->V[0], tri1->V[1], tri1->V[2]));
@@ -996,7 +996,7 @@ namespace gte
                 LogAssert(tri, "Unexpected condition.");
                 for (size_t j = 0; j < 3; ++j)
                 {
-                    auto edge = tri->E[j].lock();
+                    auto edge = tri->E[j];
                     if (edge)
                     {
                         auto siter = edges.find(EdgeKey<false>(edge->V[0], edge->V[1]));
@@ -1004,7 +1004,7 @@ namespace gte
                         {
                             // The edge is not constrained, so it allows the
                             // search to continue.
-                            auto adj = tri->T[j].lock();
+                            auto adj = tri->T[j];
                             if (adj)
                             {
                                 TriangleKey<true> akey(adj->V[0], adj->V[1], adj->V[2]);

--- a/GTE/Mathematics/VETManifoldMesh.h
+++ b/GTE/Mathematics/VETManifoldMesh.h
@@ -3,7 +3,7 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// Version: 4.0.2021.01.17
+// Version: 4.0.2021.04.22
 
 #pragma once
 
@@ -20,8 +20,8 @@ namespace gte
     public:
         // Vertex data types.
         class Vertex;
-        typedef std::shared_ptr<Vertex>(*VCreator)(int);
-        using VMap = std::unordered_map<int, std::shared_ptr<Vertex>>;
+        typedef std::unique_ptr<Vertex>(*VCreator)(int);
+        using VMap = std::unordered_map<int, std::unique_ptr<Vertex>>;
 
         // Vertex object.
         class Vertex
@@ -40,8 +40,8 @@ namespace gte
 
             // Adjacent objects.
             std::unordered_set<int> VAdjacent;
-            std::unordered_set<std::shared_ptr<Edge>> EAdjacent;
-            std::unordered_set<std::shared_ptr<Triangle>> TAdjacent;
+            std::unordered_set<Edge*> EAdjacent;
+            std::unordered_set<Triangle*> TAdjacent;
         };
 
 
@@ -83,9 +83,9 @@ namespace gte
         // returned; otherwise, <v0,v1,v2> is in the mesh and nullptr is
         // returned.  If the insertion leads to a nonmanifold mesh, the call
         // fails with a nullptr returned.
-        virtual std::shared_ptr<Triangle> Insert(int v0, int v1, int v2) override
+        virtual Triangle* Insert(int v0, int v1, int v2) override
         {
-            std::shared_ptr<Triangle> tri = ETManifoldMesh::Insert(v0, v1, v2);
+            Triangle* tri = ETManifoldMesh::Insert(v0, v1, v2);
             if (!tri)
             {
                 return nullptr;
@@ -95,22 +95,23 @@ namespace gte
             {
                 int vIndex = tri->V[i];
                 auto vItem = mVMap.find(vIndex);
-                std::shared_ptr<Vertex> vertex;
+                Vertex* vertex;
                 if (vItem == mVMap.end())
                 {
-                    vertex = mVCreator(vIndex);
-                    mVMap[vIndex] = vertex;
+                    std::unique_ptr<Vertex> newVertex = mVCreator(vIndex);
+                    vertex = newVertex.get();
+                    mVMap[vIndex] = std::move(newVertex);
                 }
                 else
                 {
-                    vertex = vItem->second;
+                    vertex = vItem->second.get();
                 }
 
                 vertex->TAdjacent.insert(tri);
 
                 for (int j = 0; j < 3; ++j)
                 {
-                    auto edge = tri->E[j].lock();
+                    auto edge = tri->E[j];
                     LogAssert(edge != nullptr, "Malformed mesh.");
                     if (edge->V[0] == vIndex)
                     {
@@ -138,18 +139,18 @@ namespace gte
                 return false;
             }
 
-            std::shared_ptr<Triangle> tri = tItem->second;
+            Triangle* tri = tItem->second.get();
             for (int i = 0; i < 3; ++i)
             {
                 int vIndex = tri->V[i];
                 auto vItem = mVMap.find(vIndex);
                 LogAssert(vItem != mVMap.end(), "Malformed mesh.");
-                std::shared_ptr<Vertex> vertex = vItem->second;
+                Vertex* vertex = vItem->second.get();
                 for (int j = 0; j < 3; ++j)
                 {
-                    auto edge = tri->E[j].lock();
+                    auto edge = tri->E[j];
                     LogAssert(edge != nullptr, "Malformed mesh.");
-                    if (edge->T[0].lock() && !edge->T[1].lock())
+                    if (edge->T[0] && !edge->T[1])
                     {
                         if (edge->V[0] == vIndex)
                         {
@@ -187,9 +188,9 @@ namespace gte
 
     protected:
         // The vertex data and default vertex creation.
-        static std::shared_ptr<Vertex> CreateVertex(int vIndex)
+        static std::unique_ptr<Vertex> CreateVertex(int vIndex)
         {
-            return std::make_shared<Vertex>(vIndex);
+            return std::make_unique<Vertex>(vIndex);
         }
 
         VCreator mVCreator;


### PR DESCRIPTION
Use unique_ptr in place of shared_ptr for manifold meshes. Weak references
are now done with raw pointers rather than weak_ptr.

Profiling showed that shared_ptr and weak_ptr operations were taking up the
majority of the CPU time for Delaunay triangulation. When performing
Delaunay with a mesh that has 467,141 vertices, this change reduced the
computation time by ~3.5 minutes (~50%) and memory usage by ~125 MB (~10%).