### PR TITLE
GTE/Graphics/Node.h: Fix typo in comment.

### DIFF
--- a/GTE/Graphics/Node.h
+++ b/GTE/Graphics/Node.h
@@ -9,7 +9,7 @@
 
 #include <Graphics/Spatial.h>
 
-// This class represents grouping nodes in a spatial hiearchy.
+// This class represents grouping nodes in a spatial hierarchy.
 
 namespace gte
 {


### PR DESCRIPTION
## Summary

Fixes one typo in a comment: "hiearchy" → "hierarchy."

Comment only. No functional changes.
