### PR TITLE
Fixed undefined behavior bug due to unintentional implicit cast.

### DIFF
--- a/GTE/Mathematics/IntrAlignedBox3OrientedBox3.h
+++ b/GTE/Mathematics/IntrAlignedBox3OrientedBox3.h
@@ -50,7 +50,7 @@ namespace gte
         struct Result
         {
             // The 'epsilon' value must be nonnegative.
-            Result(Real inEpsilon = (Real)0)
+           explicit Result(Real inEpsilon = (Real)0)
                 :
                 epsilon(inEpsilon >= (Real)0 ? inEpsilon : (Real)0)
             {

--- a/GTE/Mathematics/IntrOrientedBox3OrientedBox3.h
+++ b/GTE/Mathematics/IntrOrientedBox3OrientedBox3.h
@@ -48,7 +48,7 @@ namespace gte
         struct Result
         {
             // The 'epsilon' value must be nonnegative.
-            Result(Real inEpsilon = (Real)0)
+            explicit Result(Real inEpsilon = (Real)0)
                 :
                 epsilon(inEpsilon >= (Real)0 ? inEpsilon : (Real)0)
             {
@@ -198,7 +198,8 @@ namespace gte
             // effectively in 2D.  The edge-edge axes do not need to be tested.
             if (existsParallelPair)
             {
-                return true;
+                result.intersect = true;
+                return result;
             }
 
             // Test for separation on the axis C0 + t*A0[0]xA1[0].

--- a/GTE/Mathematics/IntrTriangle3Cylinder3.h
+++ b/GTE/Mathematics/IntrTriangle3Cylinder3.h
@@ -27,7 +27,7 @@ namespace gte
     public:
         struct Result
         {
-            Result(bool inIntersect = false)
+            explicit Result(bool inIntersect = false)
                 :
                 intersect(inIntersect)
             {


### PR DESCRIPTION
- Switched to explicit constructor to avoid similar bugs in the future.
- Added explicit to several other Result constructors

Resolves #26