### PR TITLE
add option and set PROJECT_SOURCE_DIR to make it easier to build

### DIFF
--- a/GTE/CMakeLists.txt
+++ b/GTE/CMakeLists.txt
@@ -5,6 +5,7 @@ endif()
 
 set(GTE_VERSION_MAJOR 5)
 set(GTE_VERSION_MINOR 12)
+set(PROJECT_SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 project(GTE VERSION ${GTE_VERSION_MAJOR}.${GTE_VERSION_MINOR})
 
@@ -13,3 +14,8 @@ add_subdirectory(Applications)
 add_subdirectory(Graphics)
 add_subdirectory(Mathematics)
 add_subdirectory(MathematicsGPU)
+
+option(BUILD_SAMPLES "Build Samples" OFF)
+if(BUILD_SAMPLES)
+  add_subdirectory(Samples)
+endif()


### PR DESCRIPTION
This PR add an option in the main CMakeLists.txt to make it easier to build the library and the samples together.
To do so run from the repo root

    mkdir build && cd build
    cmake ../GTE -DBUILD_SAMPLES=ON
    cmake --build .

It also set the PROJECT_SOURCE_DIR variable.