### PR TITLE
Fix missing 'override' keyword in BaseEngine daughter classes

### DIFF
--- a/GTE/Applications/GLX/Window.h
+++ b/GTE/Applications/GLX/Window.h
@@ -38,7 +38,7 @@ namespace gte
     public:
         virtual ~Window();
 
-        virtual void SetTitle(std::wstring const& title);
+        virtual void SetTitle(std::wstring const& title) override;
 
         // Draw the window.
         void ShowWindow();

--- a/GTE/Graphics/GL45/GL45Engine.h
+++ b/GTE/Graphics/GL45/GL45Engine.h
@@ -137,14 +137,14 @@ namespace gte
 
         // The function returns 'true' when the depth range is [0,1] (DirectX)
         // or 'false' when the depth range is [-1,1] (OpenGL).
-        virtual bool HasDepthRange01() const
+        virtual bool HasDepthRange01() const override
         {
             return false;
         }
 
         // Append the extension of the shader file to 'name' (.hlsl for DirectX,
         // .glsl for OpenGL).
-        virtual std::string GetShaderName(std::string const& name) const
+        virtual std::string GetShaderName(std::string const& name) const override
         {
             return name + ".glsl";
         }

--- a/GTE/Graphics/GraphicsEngine.h
+++ b/GTE/Graphics/GraphicsEngine.h
@@ -106,8 +106,8 @@ namespace gte
         void GetTotalAllocation(size_t& numBytes, size_t& numObjects) const;
 
         // Support for copying from CPU to GPU via mapped memory.
-        virtual bool Update(std::shared_ptr<Buffer> const& buffer) = 0;
-        virtual bool Update(std::shared_ptr<TextureSingle> const& texture) = 0;
+        virtual bool Update(std::shared_ptr<Buffer> const& buffer) override = 0;
+        virtual bool Update(std::shared_ptr<TextureSingle> const& texture) override = 0;
         virtual bool Update(std::shared_ptr<TextureSingle> const& texture, unsigned int level) = 0;
         virtual bool Update(std::shared_ptr<TextureArray> const& textureArray) = 0;
         virtual bool Update(std::shared_ptr<TextureArray> const& textureArray, unsigned int item, unsigned int level) = 0;
@@ -184,7 +184,7 @@ namespace gte
     protected:
 
         // Helper for destruction.
-        virtual void DestroyDefaultGlobalState();
+        virtual void DestroyDefaultGlobalState() override;
 
         // Support for drawing.  If occlusion queries are enabled, the return
         // values are the number of samples that passed the depth and stencil


### PR DESCRIPTION
Dear David, 

I took upon myself to fix the missing override keywords to save you the time !

Best,
Thibault