### PR TITLE
Fix some unused variables triggering an error during compilation

### DIFF
--- a/GTE/Applications/GLX/WindowSystem.cpp
+++ b/GTE/Applications/GLX/WindowSystem.cpp
@@ -27,7 +27,7 @@ WindowSystem::~WindowSystem()
 
 WindowSystem::WindowSystem()
     :
-    mDisplayName("GTEngineWindow"),
+    // mDisplayName("GTEngineWindow"), /*< Unused variables */
     mDisplay(nullptr)
 {
     // Connect to the X server.

--- a/GTE/Applications/GLX/WindowSystem.h
+++ b/GTE/Applications/GLX/WindowSystem.h
@@ -48,7 +48,7 @@ namespace gte
         // Window creation and destruction.
         void CreateFrom(Window::Parameters& parameters);
 
-        char const* mDisplayName;
+        // char const* mDisplayName; /*< Unused variable */
         _XDisplay* mDisplay;
         std::map<unsigned long, std::shared_ptr<Window>> mWindowMap;
     };

--- a/GTE/Graphics/GL45/GL45.cpp
+++ b/GTE/Graphics/GL45/GL45.cpp
@@ -14,8 +14,8 @@
 #include <vector>
 
 // Support for versioning.
-int constexpr OPENGL_VERSION_NONE = 0;
-int constexpr OPENGL_VERSION_1_0 = 10;
+// int constexpr OPENGL_VERSION_NONE = 0; /*< Unused variable */
+// int constexpr OPENGL_VERSION_1_0 = 10; /*< Unused variable */
 int constexpr OPENGL_VERSION_1_1 = 11;
 int constexpr OPENGL_VERSION_1_2 = 12;
 int constexpr OPENGL_VERSION_1_3 = 13;

--- a/GTE/Graphics/GL45/GL45InputLayout.cpp
+++ b/GTE/Graphics/GL45/GL45InputLayout.cpp
@@ -19,7 +19,7 @@ GL45InputLayout::~GL45InputLayout()
 GL45InputLayout::GL45InputLayout(GLuint programHandle, GLuint vbufferHandle,
     VertexBuffer const* vbuffer)
     :
-    mProgramHandle(programHandle),
+    // mProgramHandle(programHandle), /*< Unused variable */
     mVBufferHandle(vbufferHandle),
     mNumAttributes(0)
 {

--- a/GTE/Graphics/GL45/GL45InputLayout.h
+++ b/GTE/Graphics/GL45/GL45InputLayout.h
@@ -24,7 +24,7 @@ namespace gte
         void Disable();
 
     private:
-        GLuint mProgramHandle;
+        // GLuint mProgramHandle; /*< Unused variable */
         GLuint mVBufferHandle;
         GLuint mVArrayHandle;
 

--- a/GTE/Graphics/MorphController.cpp
+++ b/GTE/Graphics/MorphController.cpp
@@ -109,12 +109,12 @@ bool MorphController::Update(double applicationTime)
     float const* weights0 = &mWeights[key0 * mNumTargets];
     float const* weights1 = &mWeights[key1 * mNumTargets];
     Vector3<float> const* vertices = mVertices.data();
-    float wsum0 = 0.0f, wsum1 = 0.0f;
+    // float wsum0 = 0.0f, wsum1 = 0.0f; /*< Unused variables */
     for (size_t n = 0; n < mNumTargets; ++n)
     {
         float w = oneMinusNormTime * weights0[n] + normTime * weights1[n];
-        wsum0 += weights0[n];
-        wsum1 += weights1[n];
+        // wsum0 += weights0[n]; /*< Unused variables */
+        // wsum1 += weights1[n]; /*< Unused variables */
         combination = vbuffer->GetData();
         for (size_t m = 0; m < mNumVertices; ++m)
         {


### PR DESCRIPTION
Dear David, 

It turns out that with the `-Werror` flag you imposed in the _CMake_ workflow, the `clang` and `clang++` compilers throw errors at the compile stage because some declared & initialized variables are actually unused.
This PR fixes this behavior in a _soft_ manner: all responsible lines of code are commented out in case the variables were initially meant for later use.

Best, 
Thibault