### PR TITLE
Fixed infinite recursion issue when compiling with clang

### DIFF
--- a/GTE/Mathematics/BitHacks.h
+++ b/GTE/Mathematics/BitHacks.h
@@ -38,7 +38,7 @@ namespace gte
 #if defined(GTE_THROW_ON_BITHACKS_ERROR)
             LogAssert(value >= 0, "Invalid input.");
 #endif
-            return IsPowerOfTwo(static_cast<int32_t>(value));
+            return IsPowerOfTwo(static_cast<uint32_t>(value));
         }
 
         static uint32_t Log2OfPowerOfTwo(uint32_t powerOfTwo)


### PR DESCRIPTION
When compiling with clang and -Winfinite-recursion this code returns an error.
I assume the goal was to call the uint version of the method since there is a positive check just above, this changelist fixes the issue