### PR TITLE
Plane3Plane3 intersection algebraic mistake

### DIFF
--- a/GTE/Mathematics/IntrPlane3Plane3.h
+++ b/GTE/Mathematics/IntrPlane3Plane3.h
@@ -107,8 +107,8 @@ namespace gte
             //   d1 = Dot(N1,L) = c0*Dot(N0,N1) + c1*Dot(N1,N1) = c0*d + c1
             // where d = Dot(N0,N1).  These are two equations in two unknowns.
             // The solution is
-            //   c0 = (d0 - d*d1)/det
-            //   c1 = (d1 - d*d0)/det
+            //   c0 = -(d0 - d*d1)/det
+            //   c1 = -(d1 - d*d0)/det
             // where det = 1 - d^2.
 
             Result result{};
@@ -145,8 +145,8 @@ namespace gte
             }
 
             T invDet = (T)1 / ((T)1 - dot * dot);
-            T c0 = (plane0.constant - dot * plane1.constant) * invDet;
-            T c1 = (plane1.constant - dot * plane0.constant) * invDet;
+            T c0 = -(plane0.constant - dot * plane1.constant) * invDet;
+            T c1 = -(plane1.constant - dot * plane0.constant) * invDet;
             result.intersect = true;
             result.isLine = true;
             result.line.origin = c0 * plane0.normal + c1 * plane1.normal;

--- a/GTE/Mathematics/IntrPlane3Plane3.h
+++ b/GTE/Mathematics/IntrPlane3Plane3.h
@@ -103,8 +103,8 @@ namespace gte
             //   L(t) = t*Cross(N0,N1)/|Cross(N0,N1)| + c0*N0 + c1*N1
             // for some coefficients c0 and c1 and for t any real number (the
             // line parameter).  Taking dot products with the normals,
-            //   d0 = Dot(N0,L) = c0*Dot(N0,N0) + c1*Dot(N0,N1) = c0 + c1*d
-            //   d1 = Dot(N1,L) = c0*Dot(N0,N1) + c1*Dot(N1,N1) = c0*d + c1
+            //   -d0 = Dot(N0,L) = c0*Dot(N0,N0) + c1*Dot(N0,N1) = c0 + c1*d
+            //   -d1 = Dot(N1,L) = c0*Dot(N0,N1) + c1*Dot(N1,N1) = c0*d + c1
             // where d = Dot(N0,N1).  These are two equations in two unknowns.
             // The solution is
             //   c0 = -(d0 - d*d1)/det


### PR DESCRIPTION
Plane specification formula is $Ax + By + Cz + D = 0$
Written using normals is $Dot(\vec{r}, \vec{N}) + D = 0$
So, in this function $Dot(\vec{N_0}, \vec{L}(t)) = -D_0$ and $Dot(\vec{N_1}, \vec{L}(t)) = -D_1$, so minus is missing