### PR TITLE
Prevent undefined behavior resulting from dangling reference in TriangulateCDT

### DIFF
--- a/GTE/Mathematics/TriangulateCDT.h
+++ b/GTE/Mathematics/TriangulateCDT.h
@@ -656,7 +656,7 @@ namespace gte
             queue.push(input);
             while (queue.size() > 0)
             {
-                auto const& node = queue.front();
+                std::shared_ptr<PolygonTree> node = queue.front();
                 queue.pop();
                 numNodes += node->child.size();
                 for (auto const& child : node->child)
@@ -678,7 +678,7 @@ namespace gte
             queue.push(input);
             while (queue.size() > 0)
             {
-                auto const& node = queue.front();
+                std::shared_ptr<PolygonTree> node = queue.front();
                 queue.pop();
                 auto& exnode = output.nodes[current++];
                 exnode.polygon = node->polygon;


### PR DESCRIPTION
Hello David, 

I believe I've stumbled across an issue in TriangulateCDT.h which results in UB. 

The newer version of the `CopyAndCompactify` function binds a reference to the element at the front of the queue, but the subsequent call to `queue.pop()` removes the element and calls its destructor, leaving the reference dangling. 

The deprecated version of the same function takes a _copy_ of the shared_ptr instead, and in my case updating the new function to match prevented a segfault.

If you'd rather I raise this as an issue, please let me know.