### PR TITLE
Added install targets for Mathematics Header Only library

### DIFF
--- a/GTE/Mathematics/CMakeLists.txt
+++ b/GTE/Mathematics/CMakeLists.txt
@@ -1,1 +1,70 @@
-project(gtmathematics VERSION ${GTE_VERSION_MAJOR}.${GTE_VERSION_MINOR})
+# Define the project
+project(gtmathematics
+    VERSION ${GTE_VERSION_MAJOR}.${GTE_VERSION_MINOR}
+    DESCRIPTION "A header-only mathematics library"
+    LANGUAGES CXX
+)
+
+# Minimum CMake version
+cmake_minimum_required(VERSION 3.14)
+
+include(GNUInstallDirs)
+
+# Define the library as INTERFACE, which is typical for header-only libraries
+add_library(gtmathematics INTERFACE)
+
+# Set the include directories where the headers are located
+# Assuming headers are in an "include" folder next to this CMakeLists.txt
+target_include_directories(gtmathematics
+    INTERFACE 
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+# Installation support
+include(CMakePackageConfigHelpers)
+
+# Find all .h files in the same directory as this CMakeLists.txt
+file(GLOB HEADER_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+
+# Install the header files
+install(FILES ${HEADER_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${PROJECT_NAME}/Mathematics)
+
+# Install the target (export for downstream use)
+install(
+    TARGETS gtmathematics
+    EXPORT gtmathematicsTargets
+    INCLUDES DESTINATION include
+)
+
+# Generate and install the CMake package config file
+install(EXPORT gtmathematicsTargets
+    FILE gtmathematicsTargets.cmake
+    NAMESPACE GTE::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/gtmathematics
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/gtmathematicsConfigVersion.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/gtmathematicsConfig.cmake.in" # Template file
+    "${CMAKE_CURRENT_BINARY_DIR}/gtmathematicsConfig.cmake"
+    INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/gtmathematics
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/gtmathematicsConfig.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/gtmathematicsConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/gtmathematics
+)
+
+# Configure the export for a local build for find_package() to work
+export(EXPORT gtmathematicsTargets
+    FILE gtmathematicsTargets.cmake
+    NAMESPACE GTE::
+)

--- a/GTE/Mathematics/cmake/gtmathematicsConfig.cmake.in
+++ b/GTE/Mathematics/cmake/gtmathematicsConfig.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+# Include the automatically generated targets file
+include("${CMAKE_CURRENT_LIST_DIR}/gtmathematicsTargets.cmake")


### PR DESCRIPTION
What is this MR good for:
We want to use the Mathematics Header Only library from another project. We also want to keep the packages separate, so we can keep track of the used software and also can obey OSS licenses. We therefore benefit, if the library was able to install into a prefix (or /usr) and expose itself with a cmake target / config file.

This wraps the Mathematics Header Only part of the library as a proper cmake package and installs the headers into include prefix and gtmathematics subdirectory. This then can be found using find_package(gtmathematics).

Of course, the project is much large, but I will only do a rework of the cmake code used here, if it is wanted. This is kind of a sneak peak ;) 

It should not hurt the way, the library has been used before. But then, I do not have Windows nor do I use the Mircrosoft compiler (btw. did you know, cmake can also generate visual code projects?) 

Any feeback, comments or change requests are welcome. 