### PR TITLE
Require numPoints >= 3 for NaturalCubicSpline and NaturalQuinticSpline

### DIFF
--- a/GTE/Mathematics/NaturalCubicSpline.h
+++ b/GTE/Mathematics/NaturalCubicSpline.h
@@ -3,13 +3,13 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// File Version: 8.0.2025.05.10
+// File Version: 8.0.2026.02.18
 
 #pragma once
 
 // Documentation for natural splines is found in
 // https://www.geometrictools.com/Documentation/NaturalSplines.pdf
-// The number of points must be 2 or larger. The points[] and times[] arrays
+// The number of points must be 3 or larger. The points[] and times[] arrays
 // must have the same number of elements. The times[] values must be strictly
 // increasing.
 
@@ -37,7 +37,7 @@ namespace gte
             mDelta{}
         {
             LogAssert(
-                numPoints >= 2 && f0 != nullptr && times != nullptr,
+                numPoints >= 3 && f0 != nullptr && times != nullptr,
                 "Invalid input.");
 
             int32_t numPm1 = numPoints - 1;
@@ -99,7 +99,7 @@ namespace gte
             mDelta{}
         {
             LogAssert(
-                numPoints >= 2 && f0 != nullptr && times != nullptr,
+                numPoints >= 3 && f0 != nullptr && times != nullptr,
                 "Invalid input.");
 
             int32_t const numPm1 = numPoints - 1;

--- a/GTE/Mathematics/NaturalQuinticSpline.h
+++ b/GTE/Mathematics/NaturalQuinticSpline.h
@@ -3,13 +3,13 @@
 // Distributed under the Boost Software License, Version 1.0.
 // https://www.boost.org/LICENSE_1_0.txt
 // https://www.geometrictools.com/License/Boost/LICENSE_1_0.txt
-// File Version: 8.0.2025.05.10
+// File Version: 8.0.2026.02.18
 
 #pragma once
 
 // Documentation for natural splines is found in
 // https://www.geometrictools.com/Documentation/NaturalSplines.pdf
-// The number of points must be 2 or larger. The points[] and times[] arrays
+// The number of points must be 3 or larger. The points[] and times[] arrays
 // must have the same number of elements. The times[] values must be strictly
 // increasing.
 
@@ -38,7 +38,7 @@ namespace gte
             mDelta{}
         {
             LogAssert(
-                numPoints >= 2 && f0 != nullptr && f1 != nullptr && times != nullptr,
+                numPoints >= 3 && f0 != nullptr && f1 != nullptr && times != nullptr,
                 "Invalid input.");
 
             int32_t numPm1 = numPoints - 1;
@@ -108,7 +108,7 @@ namespace gte
             mDelta{}
         {
             LogAssert(
-                numPoints >= 2 && f0 != nullptr && f1 != nullptr && times != nullptr,
+                numPoints >= 3 && f0 != nullptr && f1 != nullptr && times != nullptr,
                 "Invalid input.");
 
             int32_t numPm1 = numPoints - 1;


### PR DESCRIPTION
## Summary
- With 2 points, `RowReduce` accesses `mDelta[1]` out of bounds (heap-buffer-overflow). The multi-segment solver requires at least 2 segments (3 points). Changed assertion from `numPoints >= 2` to `numPoints >= 3` in both `NaturalCubicSpline` and `NaturalQuinticSpline`, and updated documentation comment.

## Test plan
- Confirmed segfault with 2-point free quintic spline before fix (AddressSanitizer confirms heap-buffer-overflow at `NaturalQuinticSpline.h:336`)
- After fix, 2-point construction triggers clean assertion with descriptive message
- 3-point splines construct and evaluate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)